### PR TITLE
removed signif() from .parse.coding in coding.R

### DIFF
--- a/R/coding.R
+++ b/R/coding.R
@@ -37,7 +37,7 @@
     a = eval(parse(text = sub(nm[2], "0", rhs)))
     b = eval(parse(text = sub(nm[2], "1", rhs)))
     d = 1 / (b - a)
-    list(names = nm, const=c(center = signif(-a * d, 4), divisor = signif(d, 4)))
+    list(names = nm, const=c(center = -a * d, divisor = d))
 }
 
 ### figure out the "rsdes" attribute for given data


### PR DESCRIPTION
The restriction to 4 significant digits can lead to large inaccuracies, e.g. when the coded data is transformed back to original scale with decode.data().